### PR TITLE
Added Fedora support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,15 @@ env:
   - distribution: centos
     init:        /usr/lib/systemd/systemd
     version:     7
-  # - distribution: fedora
-  #   init:        /usr/lib/systemd/systemd
-  #   version:     26
-  # - distribution: fedora
-  #   init:        /usr/lib/systemd/systemd
-  #   version:     25
-  # - distribution: fedora
-  #   init:        /usr/lib/systemd/systemd
-  #   version:     24
+  - distribution: fedora
+    init:        /usr/lib/systemd/systemd
+    version:     26
+  - distribution: fedora
+    init:        /usr/lib/systemd/systemd
+    version:     25
+  - distribution: fedora
+    init:        /usr/lib/systemd/systemd
+    version:     24
   # - distribution: ubuntu
   #   init:        /lib/systemd/systemd
   #   version:     bionic

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,12 @@ galaxy_info:
       versions:
         - jessie
         - stretch
+    - name: Fedora
+      versions:
+        - 24
+        - 25
+        - 26
+        - 27
     - name: Ubuntu
       versions:
         - trusty

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -16,9 +16,36 @@
   become: true
   when: ansible_distribution != "Fedora"
 
+- name: redhat | Adding Powershell Repo
+  yum_repository:
+    name: packages-microsoft-com-prod
+    description: packages-microsoft-com-prod
+    baseurl: "https://packages.microsoft.com/rhel/7/prod/"
+    gpgkey: https://packages.microsoft.com/keys/microsoft.asc
+    gpgcheck: true
+    enabled: true
+  become: true
+  when: ansible_distribution == "Fedora"
+
+- name: redhat | Installing compat-openssl10
+  dnf:
+    name: compat-openssl10
+    state: present
+  become: true
+  when: >
+        ansible_distribution == "Fedora" and
+        ansible_distribution_major_version is version('26', '>=')
+
 - name: redhat | Installing Powershell
   yum:
     name: powershell
     state: present
   become: true
   when: ansible_distribution != "Fedora"
+
+- name: redhat | Installing Powershell
+  dnf:
+    name: powershell
+    state: present
+  become: true
+  when: ansible_distribution == "Fedora"


### PR DESCRIPTION
This resolves #1
Added support for Fedora 24-27. Enabled Travis-CI tests for Fedora
24-26.